### PR TITLE
Remove not existing getContainer() call

### DIFF
--- a/src/Command/LoadDataFixturesDoctrineCommand.php
+++ b/src/Command/LoadDataFixturesDoctrineCommand.php
@@ -104,7 +104,7 @@ EOT
 			$paths = $this->paths;
 		}
 
-		$loader = new DataFixturesLoader($this->getContainer());
+		$loader = new DataFixturesLoader();
 		foreach ($paths as $path) {
 			if (is_dir($path)) {
 				$loader->loadFromDirectory($path);


### PR DESCRIPTION
This calling is executed just in windows PHP7.1RC-1, and causes error.
